### PR TITLE
Add https:// behind domain name

### DIFF
--- a/rootfs/etc/templates.d/parameters.yml
+++ b/rootfs/etc/templates.d/parameters.yml
@@ -31,7 +31,7 @@ parameters:
 
   locale:            en
 
-  domain_name: https://{{ .DOMAIN_NAME }}
+  domain_name: {{ .DOMAIN_NAME }}
   # A secret key that's used to generate certain security-related tokens
   secret: {{ .SECRET }}
 

--- a/rootfs/etc/templates.d/parameters.yml
+++ b/rootfs/etc/templates.d/parameters.yml
@@ -31,7 +31,7 @@ parameters:
 
   locale:            en
 
-  domain_name: {{ .DOMAIN_NAME }}
+  domain_name: https://{{ .DOMAIN_NAME }}
   # A secret key that's used to generate certain security-related tokens
   secret: {{ .SECRET }}
 


### PR DESCRIPTION
Curiously, wallabag send a HTTP error 500 when domain name equal domain.tld, but when it look like https://domain.tld it's work o/
So, I change this file... Or change README and write https://domain.tld 

Your choise ;)